### PR TITLE
chore(dependencies): add remark-gfm package to client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -276,6 +276,7 @@
         "react-toastify": "^11.0.5",
         "react-tooltip": "^5.28.1",
         "react-virtualized": "^9.22.6",
+        "remark-gfm": "^4.0.0",
         "rrule": "^2.8.1",
         "shared": "workspace:*",
         "socket.io-client": "^4.8.1",

--- a/client/package.json
+++ b/client/package.json
@@ -75,6 +75,7 @@
     "react-toastify": "^11.0.5",
     "react-tooltip": "^5.28.1",
     "react-virtualized": "^9.22.6",
+    "remark-gfm": "^4.0.0",
     "rrule": "^2.8.1",
     "shared": "workspace:*",
     "socket.io-client": "^4.8.1",

--- a/server/src/lib/locales/routes/locales.ts
+++ b/server/src/lib/locales/routes/locales.ts
@@ -8,11 +8,8 @@ import { z } from 'zod/v4'
 import { ALLOWED_LANG, ALLOWED_NAMESPACE } from '../constants/locales'
 
 export const allApps = fs
-  .globSync(['../client/src/apps/*/*', '../apps/*'], {
-    withFileTypes: true
-  })
-  .filter(e => fs.existsSync(`${e.parentPath}/${e.name}/locales`))
-  .map(e => `${e.parentPath}/${e.name}`)
+  .globSync(['../client/src/apps/*/*', '../apps/*'])
+  .filter(e => fs.existsSync(`${e}/locales`))
 
 const getLocale = forgeController
   .query()


### PR DESCRIPTION
- Add `remark-gfm` to the client package.json because it is used in this file https://github.com/Lifeforge-app/lifeforge/blob/0e8bed6571eb242b844d717075f0430eb45892c6/client/src/core/pages/Dashboard/modals/ForgeAgentModal/index.tsx#L12
build fails sometimes because of it, probably a concurrently race condition, remark-gfm is included in docs dependencies I didn't bother to debug what happens but it's used in the client, so it has to be in its package.json.

- Update code that isn't compatible with bun runtime, check issue: https://github.com/oven-sh/bun/issues/22018?utm_source=chatgpt.com

Question: @melvinchia3636  are you using node runtime or bun? because server build is done with bun but server running (at least according to current docs) doesn't use the build. In production, do you use `bun run forge build server` or `bun run forge start server` because `start` uses tsx (node!)