### PR TITLE
feat(docs): Added important section about finishing minimal installation and db initialization

### DIFF
--- a/docs/src/contents/02.user-guide/02.Modules.mdx
+++ b/docs/src/contents/02.user-guide/02.Modules.mdx
@@ -155,6 +155,10 @@ Installing a module takes just a few simple steps. Before you begin, make sure:
 
 ### Step-by-Step Installation
 
+<Alert className="mt-6" type="important">
+  Make sure you have finished [basic installation steps](/getting-started/installation) and [initialized the database](/getting-started/configuration) before continuing in this section! If not, you may come into Bun's out-of-memory issues or database migration failed during installations.
+</Alert>
+
 **Step 1:** Open your terminal and navigate to your LifeForge folder.
 
 **Step 2:** Run the install command with the module name:
@@ -174,6 +178,8 @@ Let's say you want to install the Calendar module. Here's exactly what you would
 ```bash
 bun forge modules install lifeforge--calendar
 ```
+
+And there you go! Go back to your LifeForge dashboard, and you'll find the Calendar module appears on your sidebar.
 
 ### Installing Multiple Modules at Once
 


### PR DESCRIPTION
tldr: Added sections to alert users to complete installation & initialization steps before installing modules, as bun's out-of-memory error comes from one of these issue due to bun's bug.

Part of the small changes for #90 

---

This pull request improves the user documentation for installing modules by adding important guidance and clarifications to help users avoid common setup issues.

Documentation improvements:

* Added an alert at the beginning of the installation steps reminding users to complete the basic installation and database initialization before proceeding, to prevent out-of-memory or migration errors.
* Clarified that after installing a module (using the Calendar module as an example), users should see the new module appear in the LifeForge dashboard sidebar.