### PR TITLE
fix(ui): use method shorthand in mockController so this resolves

### DIFF
--- a/packages/ui/src/storybook/mockController.ts
+++ b/packages/ui/src/storybook/mockController.ts
@@ -13,10 +13,10 @@ export function mockController() {
         mutationFn: async () => true
       }
     },
-    setHost: () => {
+    setHost() {
       return this
     },
-    input: () => {
+    input() {
       return this
     },
     get key() {


### PR DESCRIPTION
### Problem

`pnpm install` fails on a fresh clone of main: postinstall runs
`turbo build --filter="./packages/*"`, and `@lifeforge/ui` doesn't compile.

    packages/ui/src/storybook/mockController.ts(17,14): error TS2683: 'this'
    implicitly has type 'any' because it does not have a type annotation.
    packages/ui/src/storybook/mockController.ts(20,14): error TS2683: ...

`setHost` and `input` are arrow-function properties, so they have no own `this`.
Besides the type error, at runtime `this` would resolve to the enclosing scope
rather than the mock controller, which breaks chaining.

### Fix

Convert both to method shorthand, so `this` is inferred as the object literal.

### Verification

`pnpm install` completes cleanly and `@lifeforge/ui:build` passes
(Ubuntu, Node 24, pnpm 11.13.0).